### PR TITLE
Fix check of result of check_md5 function call

### DIFF
--- a/bin/buildDockerImage.sh
+++ b/bin/buildDockerImage.sh
@@ -45,8 +45,9 @@ then
   exit
 fi
 
+
 check_md5 $JAVA_PKG $JAVA_PKG_MD5
-if [ "$?" -eq 0 ]
+if [ "$?" -ne 0 ]
 then
   echo "MD5 for $JAVA_PKG does not match! Download again!"
   exit
@@ -64,7 +65,7 @@ then
 fi
 
 check_md5 $WLS_PKG $WLS_PKG_MD5
-if [ "$?" -eq 0 ]
+if [ "$?" -ne 0 ]
 then
   echo "MD5 for $WLS_PKG does not match! Download again!"
   exit

--- a/bin/setDockerEnv.sh
+++ b/bin/setDockerEnv.sh
@@ -31,7 +31,7 @@ setup_developer() {
 # Function to check MD5 of $1 against expected value $2
 #
 check_md5() {
-  echo "check_md5 $1 $2" 
+#  echo "check_md5 $1 $2" 
   if [[ "`uname`" == 'Darwin' ]]; then
     MD5_CHECK=`md5 "$1"`
     MD5="MD5 ($1) = $2"


### PR DESCRIPTION
The check of the return of md5_check was around the wrong way - it returns 0 as OK, 1 as error.  

-if [ "$?" -eq 0 ]
+if [ "$?" -ne 0 ]